### PR TITLE
adding metadata in single upload function

### DIFF
--- a/bulkboto3/bulkboto3.py
+++ b/bulkboto3/bulkboto3.py
@@ -18,9 +18,18 @@ from .transfer_path import StorageTransferPath
 logger = logging.getLogger(__name__)
 
 
-def single_upload(input_tuple):
+def single_upload(input_tuple, metadata=None):
+    '''
+    :param input_tuple: (bucket, upload_path)
+    :param metadata: {'ContentType': content_type}
+    :return:
+    '''
     bucket, upload_path = input_tuple
-    bucket.upload_file(upload_path.local_path, upload_path.storage_path)
+    extra_args = {}
+    if metadata:
+        extra_args['Metadata'] = metadata
+
+    bucket.upload_file(upload_path.local_path, upload_path.storage_path, extra_args=extra_args)
 
 
 def single_download(input_tuple):


### PR DESCRIPTION
Added the metadata field in single upload function. 

Metadata is important while uploading each file. because When you click on File URL It will download automatically if you dont define contentType in metadata